### PR TITLE
prepare update to scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ libraryDependencies += "io.dataflint" %% "spark_2.12" % "0.1.1"
 Then instruct spark to load the DataFlint plugin:
 ```scala
 val spark = SparkSession
-    .builder
+    .builder()
     .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
     ...
     .getOrCreate()

--- a/spark-plugin/example_3_1_3/src/main/scala/io/dataflint/example/ShakespeareSpark313.scala
+++ b/spark-plugin/example_3_1_3/src/main/scala/io/dataflint/example/ShakespeareSpark313.scala
@@ -19,7 +19,7 @@ object ShakespeareSpark313 {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_2_4/src/main/scala/io/dataflint/example/ShakespeareSpark324.scala
+++ b/spark-plugin/example_3_2_4/src/main/scala/io/dataflint/example/ShakespeareSpark324.scala
@@ -19,7 +19,7 @@ object ShakespeareSpark324 {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_3_3/src/main/scala/io/dataflint/example/ShakespeareSpark333.scala
+++ b/spark-plugin/example_3_3_3/src/main/scala/io/dataflint/example/ShakespeareSpark333.scala
@@ -19,7 +19,7 @@ object ShakespeareSpark333 {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/SalesFilterer.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/SalesFilterer.scala
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 object SalesFilterer {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Sales Filterer")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/SalesFiltererFixed.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/SalesFiltererFixed.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.{SaveMode, SparkSession}
 object SalesFiltererFixed {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Sales Filterer Fixed")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/Shakespeare341.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/Shakespeare341.scala
@@ -19,7 +19,7 @@ object Shakespeare341 {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespearePartitionedWriter.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespearePartitionedWriter.scala
@@ -9,7 +9,7 @@ object ShakespearePartitionedWriter {
     Paths.get(this.getClass.getResource(resource).toURI).toString
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Partitioned Writer")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespearePartitionedWriterFixed.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespearePartitionedWriterFixed.scala
@@ -9,7 +9,7 @@ object ShakespearePartitionedWriterFixed {
     Paths.get(this.getClass.getResource(resource).toURI).toString
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Partitioned Writer Fixed")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespeareUnpartitionedWriter.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespeareUnpartitionedWriter.scala
@@ -9,7 +9,7 @@ object ShakespeareUnpartitionedWriter {
     Paths.get(this.getClass.getResource(resource).toURI).toString
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Unpartitioned Writer")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespeareUnpartitionedWriterFixed.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/ShakespeareUnpartitionedWriterFixed.scala
@@ -9,7 +9,7 @@ object ShakespeareUnpartitionedWriterFixed {
     Paths.get(this.getClass.getResource(resource).toURI).toString
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Unpartitioned Writer Fixed")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/SimpleStreaming.scala
+++ b/spark-plugin/example_3_4_1/src/main/scala/io/dataflint/example/SimpleStreaming.scala
@@ -8,7 +8,7 @@ import java.sql.Timestamp
 object SimpleStreaming {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Simple Streaming")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_4_1_remote/src/main/scala/io/dataflint/example/Shakespeare341Remote.scala
+++ b/spark-plugin/example_3_4_1_remote/src/main/scala/io/dataflint/example/Shakespeare341Remote.scala
@@ -21,7 +21,7 @@ object Shakespeare341Remote {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics")
       .config("spark.ui.port", "10000")
       .master("local[*]")

--- a/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/DeltaLakeExample.scala
+++ b/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/DeltaLakeExample.scala
@@ -7,7 +7,7 @@ import java.sql.Timestamp
 object DeltaLakeExample {
     def main(args: Array[String]): Unit = {
       val spark = SparkSession
-        .builder
+        .builder()
         .appName("DeltaLakeExample")
         .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
         .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/DeltaLakeStreaming.scala
+++ b/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/DeltaLakeStreaming.scala
@@ -7,7 +7,7 @@ import java.sql.Timestamp
 object DeltaLakeStreaming {
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Simple Streaming")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/KafkaStreaming.scala
+++ b/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/KafkaStreaming.scala
@@ -6,7 +6,7 @@ object KafkaStreaming {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Simple Streaming")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/Shakespeare350.scala
+++ b/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/Shakespeare350.scala
@@ -19,7 +19,7 @@ object Shakespeare350 {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/Shakespeare350Exported.scala
+++ b/spark-plugin/example_3_5_0/src/main/scala/io/dataflint/example/Shakespeare350Exported.scala
@@ -19,7 +19,7 @@ object Shakespeare350Exported {
 
   def main(args: Array[String]): Unit = {
     val spark = SparkSession
-      .builder
+      .builder()
       .appName("Shakespeare Statistics Exported")
       .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
       .config("spark.ui.port", "10000")

--- a/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/DataflintSQLMetricsPage.scala
+++ b/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/DataflintSQLMetricsPage.scala
@@ -35,7 +35,7 @@ class DataflintSQLMetricsPage(ui: SparkUI, sqlListener: () => Option[SQLAppStatu
         sqlStore.planGraph(executionIdLong)
       val nodesMetrics = graph.allNodes.map(node => NodeMetrics(node.id, node.name, node.metrics.map(metric => {
           NodeMetric(metric.name, metrics.get(metric.accumulatorId))
-        })))
+        }).toSeq))
         // filter nodes without metrics
         .filter(nodeMetrics => !nodeMetrics.metrics.forall(_.value.isEmpty))
       val jValue: JValue = Extraction.decompose(nodesMetrics)(org.json4s.DefaultFormats)

--- a/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/DataflintSQLPlanPage.scala
+++ b/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/DataflintSQLPlanPage.scala
@@ -55,7 +55,7 @@ class DataflintSQLPlanPage(ui: SparkUI, sqlListener: () => Option[SQLAppStatusLi
             }
             else None
             NodePlan(node.id, node.desc, rddScopeId)
-          })
+          }).toSeq
         )
       }
       val jsonValue: JValue = Extraction.decompose(sqlPlans)(org.json4s.DefaultFormats)


### PR DESCRIPTION
Hello!
Nice work and very interesting plugin!

However I would like to try it on a project that is running with Spark using Scala 2.13 and it doesn't work.
I am getting

```log
 Exception in thread "main" java.lang.NoSuchMethodError: 'scala.collection.GenMap scala.collection.immutable.Map$.apply(scala.collection.Seq)'
13:43:19 	at io.dataflint.spark.SparkDataflintDriverPlugin.init(SparkDataflintPlugin.scala:21)
...
```

I tried to fix that (using `toSeq` - which converts the mutable Seq to an immutable one)
also I added a few `()` that Scala 2.13 complained about. This all compiles also with Scala 2.12.

Btw Scala 2.12 is deprecated with Spark 3.5.x and 2.13 is the default now AFAIK.

Probably this will be enough to run it with Scala 2.13 and it would be nice if you created a new release that I would test.
