### PR TITLE
Update TypeScript target to es2018 to fix build error

### DIFF
--- a/spark-ui/package.json
+++ b/spark-ui/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "dataflint-ui",
   "version": "0.2.2",
@@ -16,6 +17,8 @@
     "@types/graphlib": "^2.1.8",
     "@types/react": "latest",
     "@types/react-dom": "latest",
+    "ajv": "^8.17.1",
+    "ajv-keywords": "^5.1.0",
     "apexcharts": "^3.45.1",
     "bytes": "^3.1.2",
     "dagre": "^0.8.5",

--- a/spark-ui/tsconfig.json
+++ b/spark-ui/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Set TypeScript target to es2018 in tsconfig.json to ensure compatibility with newer JavaScript features.
- The ajv and ajv-keywords packages were addedt to resolve dependency issues related to JSON schema validation.