### PR TITLE
Add large broadcast example

### DIFF
--- a/spark-plugin/example_3_5_1/src/main/scala/io/dataflint/example/LargeBroadcastExample.scala
+++ b/spark-plugin/example_3_5_1/src/main/scala/io/dataflint/example/LargeBroadcastExample.scala
@@ -1,0 +1,37 @@
+package main.scala.io.dataflint.example
+
+import io.dataflint.example.AccessPatternExample.spark
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+object LargeBroadcastExample extends App {
+
+
+  val spark = SparkSession
+    .builder()
+    .appName("LargeBroadcastExample")
+    .config("spark.plugins", "io.dataflint.spark.SparkDataflintPlugin")
+    .config("spark.dataflint.telemetry.enabled", false)
+    .config("spark.ui.port", "10000")
+    .config("spark.dataflint.telemetry.enabled", value = false)
+    .config("spark.sql.maxMetadataStringLength", "10000")
+    .config("spark.driver.memory", "8g")
+    .config("spark.eventLog.enabled", "true")
+    .config("spark.eventLog.dir", "/opt/spark/conf/spark-events")
+    .master("local[*]")
+    .getOrCreate()
+
+  import spark.implicits._
+
+  val numberRows = sys.env.get("NUMBER_OF_ROWS").map(_.toInt).getOrElse(100000)
+
+  val largeDF = spark.range(1, 5000000).toDF("item_sk")
+
+  val smallDF = spark.range(1, numberRows).toDF("id")
+
+  val joinedDF = largeDF.join(broadcast(smallDF), largeDF("item_sk") === smallDF("id"))
+
+  joinedDF.show()
+
+  spark.stop()
+}

--- a/spark-plugin/example_3_5_1/src/main/scala/io/dataflint/example/LargeBroadcastExample.scala
+++ b/spark-plugin/example_3_5_1/src/main/scala/io/dataflint/example/LargeBroadcastExample.scala
@@ -1,6 +1,5 @@
 package main.scala.io.dataflint.example
 
-import io.dataflint.example.AccessPatternExample.spark
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -20,9 +19,7 @@ object LargeBroadcastExample extends App {
     .config("spark.eventLog.dir", "/opt/spark/conf/spark-events")
     .master("local[*]")
     .getOrCreate()
-
-  import spark.implicits._
-
+  
   val numberRows = sys.env.get("NUMBER_OF_ROWS").map(_.toInt).getOrElse(100000)
 
   val largeDF = spark.range(1, 5000000).toDF("item_sk")
@@ -33,5 +30,6 @@ object LargeBroadcastExample extends App {
 
   joinedDF.show()
 
+  scala.io.StdIn.readLine()
   spark.stop()
 }

--- a/spark-ui/src/reducers/Alerts/MemorySQLInputOutputAlerts.ts
+++ b/spark-ui/src/reducers/Alerts/MemorySQLInputOutputAlerts.ts
@@ -155,8 +155,8 @@ export function reduceSQLInputOutputAlerts(sql: SparkSQLStore, alerts: Alerts) {
             location: `In: SQL query "${sql.description}" (id: ${sql.id}) and node "${node.nodeName}"`,
             message: `The data broadcast size is ${broadcastSizeString}, which exceeds the 1GB threshold and can cause performance issues`,
             suggestion: `
-    1. spark.sql.autoBroadcastJoinThreshold config might be set to a large number by mistake
-    2. The broadcast hint is applied on a large dataframe by mistake`,
+    1. spark.sql.autoBroadcastJoinThreshold config might be set to a large number which is not optimal
+    2. The broadcast hint is applied on a large dataframe which is not optimal`,
             type: "warning",
             source: {
               type: "sql",

--- a/spark-ui/src/reducers/Alerts/MemorySQLInputOutputAlerts.ts
+++ b/spark-ui/src/reducers/Alerts/MemorySQLInputOutputAlerts.ts
@@ -141,28 +141,30 @@ export function reduceSQLInputOutputAlerts(sql: SparkSQLStore, alerts: Alerts) {
           }
         }
       }
-      const broadcastSizeMetric = parseBytesString(
-        node.metrics.find((metric) => metric.name === "data size")?.value ?? "0",
-      );
+      if (node.nodeName === "BroadcastExchange") {
+        const broadcastSizeMetric = parseBytesString(
+          node.metrics.find((metric) => metric.name === "data size")?.value ?? "0",
+        );
 
-      if (broadcastSizeMetric > BROADCAST_SIZE_THRESHOLD) {
-        const broadcastSizeString = humanFileSize(broadcastSizeMetric);
-        alerts.push({
-          id: `largeBroadcast_${sql.id}_${node.nodeId}_${broadcastSizeString}`,
-          name: "largeBroadcast",
-          title: "Large data Broadcast ",
-          location: `In: SQL query "${sql.description}" (id: ${sql.id}) and node "${node.nodeName}"`,
-          message: `The data broadcast size is ${broadcastSizeString}, which exceeds the 1GB threshold and can cause performance issues`,
-          suggestion: `
-    1. Try to reduce the size of the broadcast data
-    2. Consider using an alternative approach that does not require broadcasting data`,
-          type: "warning",
-          source: {
-            type: "sql",
-            sqlId: sql.id,
-            sqlNodeId: node.nodeId,
-          },
-        });
+        if (broadcastSizeMetric > BROADCAST_SIZE_THRESHOLD) {
+          const broadcastSizeString = humanFileSize(broadcastSizeMetric);
+          alerts.push({
+            id: `largeBroadcast_${sql.id}_${node.nodeId}_${broadcastSizeString}`,
+            name: "largeBroadcast",
+            title: "Large data Broadcast",
+            location: `In: SQL query "${sql.description}" (id: ${sql.id}) and node "${node.nodeName}"`,
+            message: `The data broadcast size is ${broadcastSizeString}, which exceeds the 1GB threshold and can cause performance issues`,
+            suggestion: `
+    1. spark.sql.autoBroadcastJoinThreshold config might be set to a large number by mistake
+    2. The broadcast hint is applied on a large dataframe by mistake`,
+            type: "warning",
+            source: {
+              type: "sql",
+              sqlId: sql.id,
+              sqlNodeId: node.nodeId,
+            },
+          });
+        }
       }
     });
   });


### PR DESCRIPTION
* Added a new example: LargeBroadcastExample to the spark-plugin project, showcasing a large broadcast join operation.
* Introduced a new alert condition: in MemorySQLInputOutputAlerts.ts to detect and warn when a broadcast variable exceeds 1GB.