### PR TITLE
Fix History Server redirection for proxied environments

### DIFF
--- a/spark-ui/src/components/AppDrawer/DrawerFooter.tsx
+++ b/spark-ui/src/components/AppDrawer/DrawerFooter.tsx
@@ -2,6 +2,7 @@ import Button from "@mui/material/Button";
 import * as React from "react";
 import {
   BASE_CURRENT_PAGE,
+  BASE_PATH,
   IS_HISTORY_SERVER_MODE,
 } from "../../utils/UrlConsts";
 import { getBaseAppUrl, isDataFlintSaaSUI } from "../../utils/UrlUtils";
@@ -12,7 +13,7 @@ export default function DrawerFooter({ version }: { version?: string }) {
   };
 
   const onHistoryServerClick = (): void => {
-    window.location.href = `/history`;
+    window.location.href = `${BASE_PATH}/history`;
   };
 
   return (


### PR DESCRIPTION
This fix allows proper navigation back to the Spark History Server main page 
when using DataFlint through a proxy or gateway service.