### PR TITLE
Fixed redirection from hisotry server on a proxy

### DIFF
--- a/spark-ui/src/components/AppDrawer/DrawerFooter.tsx
+++ b/spark-ui/src/components/AppDrawer/DrawerFooter.tsx
@@ -5,7 +5,7 @@ import {
   BASE_PATH,
   IS_HISTORY_SERVER_MODE,
 } from "../../utils/UrlConsts";
-import { getBaseAppUrl, isDataFlintSaaSUI } from "../../utils/UrlUtils";
+import { getBaseAppUrl, isDataFlintSaaSUI, getProxyBasePath } from "../../utils/UrlUtils";
 
 export default function DrawerFooter({ version }: { version?: string }) {
   const onSparkUiClick = (): void => {
@@ -13,7 +13,8 @@ export default function DrawerFooter({ version }: { version?: string }) {
   };
 
   const onHistoryServerClick = (): void => {
-    window.location.href = `${BASE_PATH}/history`;
+    const basePath = getProxyBasePath();
+    window.location.href = basePath;
   };
 
   return (

--- a/spark-ui/src/utils/UrlUtils.ts
+++ b/spark-ui/src/utils/UrlUtils.ts
@@ -27,11 +27,11 @@ export function hrefWithoutEndSlash(): string {
   return fixedUrl;
 }
 
-export const getProxyBasePath = (): string =>
-  hrefWithoutEndSlash().substring(
-    0,
-    hrefWithoutEndSlash().lastIndexOf("/dataflint"),
-  );
+export const getProxyBasePath = (): string => {
+  const url = new URL(window.location.href);
+  const pathToRemove = /\/history\/[^/]+\/dataflint\/?$/;
+  return url.origin + url.pathname.replace(pathToRemove, '');
+};
 
 export function getHistoryServerCurrentAppId(): string {
   const urlSegments = hrefWithoutEndSlash().split("/");


### PR DESCRIPTION
**Bug issue:**
https://github.com/dataflint/spark/issues/13

**Why it happened:**

1. The getProxyBasePath function:
This implementation assumes that "/dataflint" is always the last meaningful part of the URL before the specific application details. However, in a proxy setup, there might be additional path segments between the host and "/dataflint", such as "/gateway/sparkhistory".

2. The onHistoryServerClick function:
This implementation uses BASE_PATH, which is likely a constant defined elsewhere in the application. The issue here is that BASE_PATH might not include the proxy-specific path segments (like "/gateway/sparkhistory") that are necessary to correctly construct the history server URL in a proxy setup.


**Changes:**

1. getProxyBasePath function:
    * Uses a regex /\/history\/[^/]+\/dataflint\/?$/ to match and remove '/history/[app-id]/dataflint/' from the end of any URL.
    * Correctly handles complex proxy setups by preserving everything before this pattern.
    * Example: "http://knox.local:8080/gateway/sparkhistory/history/[app-id]/dataflint" becomes "http://knox.local:8080/gateway/sparkhistory".
    
2. onHistoryServerClick function:
    * Doesn't rely on BASE_PATH, avoiding issues with incorrect constant values.
    * Uses getProxyBasePath() to dynamically determine the correct base URL.
    * Adapts to both proxy and non-proxy environments without configuration changes.
