### PR TITLE
Add filter ratio dynamic metric

### DIFF
--- a/spark-ui/src/reducers/SqlReducer.ts
+++ b/spark-ui/src/reducers/SqlReducer.ts
@@ -537,10 +537,10 @@ function addFilterRatioMetric(
       return updatedMetrics;
     }
 
-     const outputRowsMetric = updatedMetrics.find((m) => m.name.includes("rows"));
-     if (!outputRowsMetric) {
-       return updatedMetrics;
-     }
+    const outputRowsMetric = updatedMetrics.find((m) => m.name.includes("rows"));
+    if (!outputRowsMetric) {
+      return updatedMetrics;
+    }
 
     const outputRows = parseFloat(outputRowsMetric.value.replace(/,/g, ""));
     if (isNaN(outputRows)) {

--- a/spark-ui/src/reducers/SqlReducer.ts
+++ b/spark-ui/src/reducers/SqlReducer.ts
@@ -400,6 +400,7 @@ export function updateSqlNodeMetrics(
 
   const notEffectedSqls = currentStore.sqls.filter((sql) => sql.id !== sqlId);
   const runningSql = runningSqls[0];
+  // TODO: cache the graph
   const graph = generateGraph(runningSql.edges, runningSql.nodes);
   const nodes = runningSql.nodes.map((node) => {
     const matchedMetricsNodes = sqlMetrics.filter(


### PR DESCRIPTION
- calcNodeMetrics in updateSqlNodeMetrics (for live updates) and calculateSql (for completed runs) 
were replaced with updateNodeMetrics function.
- updateNodeMetrics accepts the node graph and able to add extra insights based on spark metrics and graphs insights.
- new logic for metrics add-on can be added here.
- Now there is only 1 call to addFilterRatioMetric which adds to Filter/Join nodes an extra metrics names filter_ratio (in percentage).
- base use cases like no input, stage followed by filter, more than one input node with rows and join filtering are implemented.
