### PR TITLE
skip dataflint UI on databricks spark 4 to avoid jakarta.servlet crash

### DIFF
--- a/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/DataflintSparkUICommonLoader.scala
+++ b/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/DataflintSparkUICommonLoader.scala
@@ -112,6 +112,10 @@ class DataflintSparkUICommonInstaller extends Logging {
       logInfo("DataFlint UI is already installed, skipping installation...")
       return ui.webUrl
     }
+    if (!pageFactory.isUISupported(ui)) {
+      logWarning("DataFlint UI is not supported in this environment, skipping UI installation; listeners will still run")
+      return ui.webUrl
+    }
     pageFactory.addStaticHandler(ui, "io/dataflint/spark/static/ui", ui.basePath + "/dataflint")
     val dataflintStore = new DataflintStore(store = ui.store.store)
     val tab = pageFactory.createDataFlintTab(ui)

--- a/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/api/DataflintPageFactory.scala
+++ b/spark-plugin/plugin/src/main/scala/org/apache/spark/dataflint/api/DataflintPageFactory.scala
@@ -27,6 +27,8 @@ abstract class DataflintPageFactory {
   def createSQLStagesRddPage(ui: SparkUI): WebUIPage
 
   def addStaticHandler(ui: SparkUI, resourceBase: String, contextPath: String): Unit
-  
+
   def getTabs(ui: SparkUI): Seq[WebUITab]
+
+  def isUISupported(ui: SparkUI): Boolean = true
 }

--- a/spark-plugin/pluginspark4/src/main/scala/org/apache/spark/dataflint/api/Spark4PageFactory.scala
+++ b/spark-plugin/pluginspark4/src/main/scala/org/apache/spark/dataflint/api/Spark4PageFactory.scala
@@ -44,8 +44,15 @@ class Spark4PageFactory extends DataflintPageFactory {
   override def addStaticHandler(ui: SparkUI, resourceBase: String, contextPath: String): Unit = {
     DataflintJettyUtils.addStaticHandler(ui, resourceBase, contextPath)
   }
-  
+
   override def getTabs(ui: SparkUI): Seq[WebUITab] = {
     ui.getTabs.toSeq
+  }
+
+  // Databricks Runtime 17.3 (Spark 4 based) ships javax.servlet instead of jakarta.servlet,
+  // so any access to jakarta.servlet.* in this module crashes with NoClassDefFoundError.
+  // Skip the entire DataFlint UI on Databricks; listeners (data export) still run.
+  override def isUISupported(ui: SparkUI): Boolean = {
+    !ui.conf.getOption("spark.databricks.clusterUsageTags.cloudProvider").isDefined
   }
 }


### PR DESCRIPTION
Fixes #47

## Summary
- Databricks Runtime 17.3 is Spark 4 based but keeps `javax.servlet` instead of `jakarta.servlet`, so the Spark 4 build of DataFlint crashes the driver on startup with `NoClassDefFoundError: jakarta/servlet/Servlet` from `DataflintJettyUtils.createStaticHandler`.
- Added `isUISupported(ui): Boolean = true` to `DataflintPageFactory`. `Spark4PageFactory` overrides it to return `false` when `spark.databricks.clusterUsageTags.cloudProvider` is set.
- `DataflintSparkUICommonInstaller.loadUI` short-circuits with a warning when the page factory reports the UI is unsupported — no static handler, no DataFlint tab. Listeners (data export, etc.) still run.

## Test plan
- [ ] Cluster boots on DBR 17.3 LTS with the plugin installed (no `NoClassDefFoundError`)
- [ ] DataFlint tab does not appear in the Databricks Spark UI; warning is logged
- [ ] Stock OSS Spark 4 (history server / standalone): full UI still loads as before
- [ ] Spark 3 path is unchanged